### PR TITLE
bump nexus to 6.71.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,20 @@
     <parent>
         <groupId>org.sonatype.nexus.plugins</groupId>
         <artifactId>nexus-plugins</artifactId>
-        <version>3.70.1-02</version>
+        <!-- https://mvnrepository.com/artifact/org.sonatype.nexus/nexus-repository -->
+        <version>3.71.0-06</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.weareadaptive.nexus</groupId>
     <artifactId>nexus-casc-plugin</artifactId>
-    <version>3.70.1-02</version>
+    <version>3.71.0-06</version>
     <packaging>bundle</packaging>
 
     <properties>
-        <nexus.docker.version>3.70.1</nexus.docker.version>
+        <nexus.docker.version>3.71.0</nexus.docker.version>
+        <!-- https://mvnrepository.com/artifact/org.sonatype.nexus/nexus-repository -->
+        <nexus-repository.version>3.70.1-02</nexus-repository.version>
 
         <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
@@ -65,6 +68,7 @@
             <groupId>org.sonatype.nexus</groupId>
             <artifactId>nexus-repository</artifactId>
             <scope>provided</scope>
+            <version>${nexus-repository.version}</version>
             <exclusions>
                 <exclusion>
                     <!-- Refers a version that can not be resolved in public maven repo -->


### PR DESCRIPTION
upgrade nexus dependencies for new version, ref failing dependabot https://github.com/larhauga/nexus-casc-plugin/pull/23

Todo: fix old docker-compose mvn plugin. `docker-compose` command is changed to `docker compose`
```
Error:  Failed to execute goal com.dkanejs.maven.plugins:docker-compose-maven-plugin:4.0.0:pull (pull) on project nexus-casc-plugin: Cannot run program "docker-compose": error=2, No such file or directory -> [Help 1]
```